### PR TITLE
feat: add support jwt auth type in http trigger

### DIFF
--- a/docs/zh/yaml/triggers.md
+++ b/docs/zh/yaml/triggers.md
@@ -20,11 +20,55 @@ type 目前支持：`http`, `timer`, `oss`, `log`, `mns_topic`, `cdn_events`, `t
 
 ### Http 触发器
 
-| 参数名             | 必填  | 类型           | 参数描述                                                               |
-| ------------------ | ----- | -------------- | ---------------------------------------------------------------------- |
-| authType           | True  | String         | 鉴权类型，可选值：anonymous、function                                  |
-| disableURLInternet | False | Boolean        | 是否禁用公网访问 URL，默认为 false                                     |
-| methods            | True  | List\<String\> | HTTP 触发器支持的访问方法，可选值：GET、POST、PUT、DELETE、PATCH、HEAD |
+| 参数名                    | 必填  | 类型                  | 参数描述                                                               |
+| ------------------------- | ----- | --------------------- | ---------------------------------------------------------------------- |
+| authType                  | True  | String                | 鉴权类型，可选值：anonymous、function、jwt                             |
+| disableURLInternet        | False | Boolean               | 是否禁用公网访问 URL，默认为 false                                     |
+| methods                   | True  | List\<String\>        | HTTP 触发器支持的访问方法，可选值：GET、POST、PUT、DELETE、PATCH、HEAD |
+| [authConfig](#authConfig) | False | [Struct](#authConfig) | 鉴权配置，authType 为 jwt 时必填                                       |
+
+#### authConfig
+
+| 参数名                      | 必填  | 类型                   | 参数描述                                                                                    |
+| --------------------------- | ----- | ---------------------- | ------------------------------------------------------------------------------------------- |
+| [jwks](#jwks)               | True  | [Struct](#jwks)        | Json Web Key Set，JSON 格式的 JWT 公钥列表                                                  |
+| [tokenLookup](#tokenLookup) | True  | [Struct](#tokenLookup) | 配置 JWT Token 在请求中的位置和具体参数名称，从而使函数计算 FC 可以找到您请求中的 JWT Token |
+| [claimPassBy](#claimPassBy) | False | [Struct](#claimPassBy) | 配置后可以将 JWT Claim 映射到 HTTP 请求中                                                   |
+| whitelist                   | False | List\<String>          | 请求路径白名单                                                                              |
+| blacklist                   | False | List\<String>          | 请求路径黑名单，如填写了白名单则以白名单为准                                                |
+
+#### jwks
+
+| 参数名        | 必填 | 类型                  | 参数描述                 |
+| ------------- | ---- | --------------------- | ------------------------ |
+| [keys](#keys) | True | List<[Struct](#keys)> | JSON 格式的 JWT 公钥列表 |
+
+#### keys
+
+| 参数名 | 必填  | 类型   | 参数描述                                                               |
+| ------ | ----- | ------ | ---------------------------------------------------------------------- |
+| e      | True  | String | 公钥的指数，例如 AQAB                                                  |
+| kid    | False | String | Key ID，kid 是可选的，如果 JWT 包含了 kid，函数计算会校验 kid 的一致性 |
+| key    | True  | String | 使用的加密算法的家族，例如 RSA，必填，大小写敏感                       |
+| alg    | True  | String | 使用的具体的加密算法，例如 RS256，必填，大小写敏感                     |
+| use    | True  | String | 密钥的用途，例如 sig，用于签名                                         |
+| n      | True  | String | 公钥的模值                                                             |
+
+#### tokenLookup
+
+| 参数名 | 必填  | 类型   | 参数描述                                                                                    |
+| ------ | ----- | ------ | ------------------------------------------------------------------------------------------- |
+| type   | True  | String | 读取位置，header、cookie、query、form                                                       |
+| name   | True  | String | 配置 JWT Token 在请求中的位置和具体参数名称，从而使函数计算 FC 可以找到您请求中的 JWT Token |
+| prefix | False | String | 去除前缀，仅当 type 为 header 时生效                                                        |
+
+#### claimPassBy
+
+| 参数名    | 必填  | 类型   | 参数描述                       |
+| --------- | ----- | ------ | ------------------------------ |
+| type      | True  | String | 读取位置，header、cookie、form |
+| name      | True  | String | Claim 名称                     |
+| mapedName | False | String | 映射参数名称                   |
 
 #### 权限配置相关
 

--- a/src/resources/fc/index.ts
+++ b/src/resources/fc/index.ts
@@ -22,6 +22,7 @@ import { FC_DEPLOY_RETRY_COUNT, FC_INSTANCE_EXEC_TIMEOUT } from '../../default/c
 
 import FC_Client, { fc2Client } from './impl/client';
 import { IFunction, ILogConfig, ITrigger } from '../../interface';
+import { instanceOfIHttpTriggerConfig, convertIHttTriggerConfig } from '../../interface/trigger';
 import {
   FC_API_ERROR_CODE,
   isAccessDenied,
@@ -228,11 +229,14 @@ export default class FC extends FC_Client {
       }
     }
 
-    let retry = 0;
-    logger.debug(`Deploy ${functionName} trigger:\n${JSON.stringify(config, null, 2)}`);
+    if (instanceOfIHttpTriggerConfig(config.triggerConfig)) {
+      config.triggerConfig = convertIHttTriggerConfig(config.triggerConfig);
+    }
+
     // eslint-disable-next-line no-param-reassign
     config.triggerConfig = JSON.stringify(config.triggerConfig);
 
+    let retry = 0;
     while (true) {
       try {
         if (!needUpdate) {

--- a/src/schema.json
+++ b/src/schema.json
@@ -7,16 +7,10 @@
                     "$ref": "#/definitions/IDestinationConfig"
                 },
                 "maxAsyncEventAgeInSeconds": {
-                    "type": "number",
-                    "default": 18000,
-                    "minimum": 1,
-                    "maximum": 2592000
+                    "type": "number"
                 },
                 "maxAsyncRetryAttempts": {
-                    "type": "number",
-                    "default": 3,
-                    "minimum": 0,
-                    "maximum": 8
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -244,11 +238,7 @@
         "IGpuConfig": {
             "properties": {
                 "gpuMemorySize": {
-                    "type": "number",
-                    "default": 1024,
-                    "minimum": 1024,
-                    "maximum": 24576,
-                    "multipleOf": 1024
+                    "type": "number"
                 },
                 "gpuType": {
                     "enum": [
@@ -286,12 +276,151 @@
         "IHttpTriggerConfig": {
             "properties": {
                 "authConfig": {
-                    "type": "string"
+                    "properties": {
+                        "blacklist": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "claimPassBy": {
+                            "anyOf": [
+                                {
+                                    "items": [
+                                        {
+                                            "properties": {
+                                                "mapedName": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "cookie",
+                                                        "form",
+                                                        "header"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "mapedName",
+                                                "name",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ],
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "jwks": {
+                            "properties": {
+                                "keys": {
+                                    "items": [
+                                        {
+                                            "properties": {
+                                                "alg": {
+                                                    "type": "string"
+                                                },
+                                                "e": {
+                                                    "type": "string"
+                                                },
+                                                "kid": {
+                                                    "type": "string"
+                                                },
+                                                "kty": {
+                                                    "type": "string"
+                                                },
+                                                "n": {
+                                                    "type": "string"
+                                                },
+                                                "use": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "alg",
+                                                "e",
+                                                "kty",
+                                                "n",
+                                                "use"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ],
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "keys"
+                            ],
+                            "type": "object"
+                        },
+                        "tokenLookup": {
+                            "anyOf": [
+                                {
+                                    "items": [
+                                        {
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "prefix": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "cookie",
+                                                        "form",
+                                                        "header",
+                                                        "query"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ],
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "whitelist": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "jwks"
+                    ],
+                    "type": "object"
                 },
                 "authType": {
                     "enum": [
                         "anonymous",
-                        "function"
+                        "function",
+                        "jwt"
                     ],
                     "type": "string"
                 },
@@ -332,8 +461,7 @@
                     "type": "string"
                 },
                 "timeout": {
-                    "type": "number",
-                    "minimum": 1
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -478,9 +606,9 @@
                 }
             },
             "required": [
-              "userId",
-              "groupId",
-              "mountPoints"
+                "groupId",
+                "mountPoints",
+                "userId"
             ],
             "type": "object"
         },
@@ -773,10 +901,7 @@
             "$ref": "#/definitions/ICodeUri"
         },
         "cpu": {
-            "type": "number",
-            "default": 0.35,
-            "minimum": 0.05,
-            "maximum": 16
+            "type": "number"
         },
         "customContainerConfig": {
             "$ref": "#/definitions/ICustomContainerConfig"
@@ -844,11 +969,7 @@
             ]
         },
         "memorySize": {
-          "type": "integer",
-          "default": 512,
-          "multipleOf": 64,
-          "minimum": 128,
-          "maximum": 32768
+            "type": "number"
         },
         "nasConfig": {
             "anyOf": [
@@ -874,16 +995,7 @@
             "$ref": "#/definitions/IRuntime"
         },
         "timeout": {
-          "type": "integer",
-          "default": 3,
-          "minimum": 1,
-          "maximum": 86400
-        },
-         "instanceConcurrency": {
-          "type": "integer",
-          "default": 1,
-          "minimum": 1,
-          "maximum": 100
+            "type": "number"
         },
         "tracingConfig": {
             "$ref": "#/definitions/ITracingConfig"
@@ -925,48 +1037,6 @@
         "region",
         "runtime"
     ],
-    "if": {
-      "properties": {
-        "runtime": {
-          "type": "string",
-          "const": "custom-container"
-        }
-      }
-    },
-    "then": {
-      "required": [
-        "region",
-        "functionName",
-        "runtime",
-        "customContainerConfig"
-      ]
-    },
-    "else": {
-      "if": {
-        "properties": {
-          "runtime": {
-            "type": "string",
-            "pattern": "^custom"
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "region",
-          "functionName",
-          "runtime",
-          "code"
-        ]
-      },
-      "else": {
-        "required": [
-          "region",
-          "functionName",
-          "runtime",
-          "code",
-          "handler"
-        ]
-      }
-    },
     "type": "object"
 }
+

--- a/src/subCommands/deploy/impl/trigger.ts
+++ b/src/subCommands/deploy/impl/trigger.ts
@@ -6,6 +6,7 @@ import { diffConvertYaml } from '@serverless-devs/diff';
 import { IInputs, ITrigger } from '../../../interface';
 import logger from '../../../logger';
 import Base from './base';
+import { instanceOfIHttpTriggerConfig, convertIHttTriggerConfig } from '../../../interface/trigger';
 import { GetApiType } from '../../../resources/fc';
 import { FC_API_ERROR_CODE } from '../../../resources/fc/error-code';
 import { FC_TRIGGER_DEFAULT_CONFIG } from '../../../default/config';
@@ -114,6 +115,11 @@ export default class Trigger extends Base {
         continue;
       }
       const localConfig = this.local[index];
+
+      if (instanceOfIHttpTriggerConfig(localConfig.triggerConfig)) {
+        localConfig.triggerConfig = convertIHttTriggerConfig(localConfig.triggerConfig);
+      }
+
       const { diffResult, show } = diffConvertYaml(remoteConfig, localConfig);
       logger.debug(`${this.functionName}/${localConfig.triggerName} diff show:\n${show}`);
       if (!_.isEmpty(diffResult)) {

--- a/src/subCommands/plan/index.ts
+++ b/src/subCommands/plan/index.ts
@@ -6,6 +6,7 @@ import FC, { GetApiType } from '../../resources/fc';
 import { FC_API_ERROR_CODE } from '../../resources/fc/error-code';
 import logger from '../../logger';
 import { FC_TRIGGER_DEFAULT_CONFIG } from '../../default/config';
+import { instanceOfIHttpTriggerConfig, convertIHttTriggerConfig } from '../../interface/trigger';
 
 export default class Plan {
   readonly region: IRegion;
@@ -34,6 +35,14 @@ export default class Plan {
         inputs.userAgent ||
         `Component:fc3;Nodejs:${process.version};OS:${process.platform}-${process.arch}`
       }command:plan`,
+    });
+
+    this.triggers = this.triggers.map((item) => {
+      if (instanceOfIHttpTriggerConfig(item.triggerConfig)) {
+        // eslint-disable-next-line no-param-reassign
+        item.triggerConfig = convertIHttTriggerConfig(item.triggerConfig);
+      }
+      return item;
     });
   }
 


### PR DESCRIPTION
这个 PR 引入了在 HTTP 触发器中的 JWT（JSON Web 令牌）认证支持。

更改：

1. 在 interface trigger 中修改了IHttpTriggerConfig添加对应 jwt 配置。
2. 在 interface trigger 中添加了方法instanceOfIHttpTriggerConfig、convertIHttTriggerConfig。
3. 在 deploy、plan 操作中对 config 进行了对应转换操作。
4. 更新了文档以反映新的变化。