### PR TITLE
fix(2to3): read gpuType from config

### DIFF
--- a/src/subCommands/2to3/index.ts
+++ b/src/subCommands/2to3/index.ts
@@ -269,7 +269,7 @@ export default class SYaml2To3 {
       if (_.get(v.props, 'gpuMemorySize')) {
         v.props.gpuConfig = {
           gpuMemorySize: _.get(v.props, 'gpuMemorySize'),
-          gpuType: 'fc.gpu.tesla.1',
+          gpuType: _.get(v.props, 'instanceType', 'fc.gpu.tesla.1'),
         };
       }
 


### PR DESCRIPTION
2 转 3 的时候，GPU 类型目前是固定的，需要优先从原配置文件中读取