### PR TITLE
fix:instance exec 默认目录是code改为home

### DIFF
--- a/src/subCommands/instance/index.ts
+++ b/src/subCommands/instance/index.ts
@@ -76,7 +76,7 @@ export default class Instance {
     if (cmd) {
       rawData = ['bash', '-c', cmd];
     } else {
-      rawData = ['bash', '-c', 'cd /code && bash'];
+      rawData = ['bash', '-c', '(cd /code ||  cd / ) && bash'];
     }
     await this.fcSdk.instanceExec(functionName, instanceId, rawData, qualifier, true);
   }


### PR DESCRIPTION
fix:instance exec 默认目录是code改为home