### PR TITLE
chore: bump version to 0.1.1 and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@alicloud/devs20230714": "^2.4.6-alpha.2",
         "@alicloud/fc2": "^2.6.6",
-        "@alicloud/fc20230330": "4.6.2",
+        "@alicloud/fc20230330": "4.6.3",
         "@alicloud/pop-core": "^1.8.0",
         "@serverless-cd/srm-aliyun-oss": "^0.0.1-beta.6",
         "@serverless-cd/srm-aliyun-pop-core": "^0.0.8-beta.1",
@@ -213,9 +213,9 @@
       }
     },
     "node_modules/@alicloud/fc20230330": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmmirror.com/@alicloud/fc20230330/-/fc20230330-4.6.2.tgz",
-      "integrity": "sha512-wrh8JK88CrM0t00GXW/hWkVBoLX2ReOM7nf8Hem6gaWeoB9SE9XX5j/eV7lBpmb7AwzCj8Tc5nXBNpByZhSGlw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmmirror.com/@alicloud/fc20230330/-/fc20230330-4.6.3.tgz",
+      "integrity": "sha512-Kga13qzSsTOSWWZGnAu4BncajBRwJCu5k6YJboZTFLzB4RZdO2n/4m5+twe66rbeN3Vl5gcqDFmCQsHlEbVy1g==",
       "dependencies": {
         "@alicloud/openapi-core": "^1.0.0",
         "@darabonba/typescript": "^1.0.0"
@@ -16165,9 +16165,9 @@
       }
     },
     "@alicloud/fc20230330": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmmirror.com/@alicloud/fc20230330/-/fc20230330-4.6.2.tgz",
-      "integrity": "sha512-wrh8JK88CrM0t00GXW/hWkVBoLX2ReOM7nf8Hem6gaWeoB9SE9XX5j/eV7lBpmb7AwzCj8Tc5nXBNpByZhSGlw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmmirror.com/@alicloud/fc20230330/-/fc20230330-4.6.3.tgz",
+      "integrity": "sha512-Kga13qzSsTOSWWZGnAu4BncajBRwJCu5k6YJboZTFLzB4RZdO2n/4m5+twe66rbeN3Vl5gcqDFmCQsHlEbVy1g==",
       "requires": {
         "@alicloud/openapi-core": "^1.0.0",
         "@darabonba/typescript": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@alicloud/devs20230714": "^2.4.6-alpha.2",
     "@alicloud/fc2": "^2.6.6",
-    "@alicloud/fc20230330": "4.6.2",
+    "@alicloud/fc20230330": "4.6.3",
     "@alicloud/pop-core": "^1.8.0",
     "@serverless-cd/srm-aliyun-pop-core": "^0.0.8-beta.1",
     "@serverless-cd/srm-aliyun-ram20150501": "^0.0.2-beta.9",

--- a/publish.yaml
+++ b/publish.yaml
@@ -3,7 +3,7 @@ Type: Component
 Name: fc3
 Provider:
   - 阿里云
-Version: 0.1.0
+Version: 0.1.1
 Description: 阿里云函数计算全生命周期管理
 HomePage: https://github.com/devsapp/fc3
 Organization: 阿里云函数计算（FC）
@@ -15,10 +15,10 @@ Category: 基础云服务
 
 Service:
   函数计算:
-    Authorities: 
+    Authorities:
       - AliyunFCFullAccess
 
-Commands: 
+Commands:
   deploy: 部署函数
   build: 构建函数
   remove: 删除函数

--- a/src/commands-help/index.ts
+++ b/src/commands-help/index.ts
@@ -14,6 +14,7 @@ import build from './build';
 import local from './local';
 import s2tos3 from './s2tos3';
 import logs from './logs';
+import scaling from './scaling';
 
 export default {
   deploy,
@@ -32,4 +33,5 @@ export default {
   local,
   s2tos3,
   logs,
+  scaling,
 };


### PR DESCRIPTION
- Update @alicloud/fc20230330 dependency from 4.6.2 to 4.6.3
- Bump component version from 0.1.0 to 0.1.1 in publish.yaml
- Add scaling command to help documentation
- Update formatting in publish.yaml
