### PR TITLE
fix: provisionConfig and scalingConfig array property handling

### DIFF
--- a/__tests__/e2e/ci-mac-linux.sh
+++ b/__tests__/e2e/ci-mac-linux.sh
@@ -88,9 +88,19 @@ s remove -y -t ./go/s.yaml
 rm -rf ./go/code/target
 cd ..
 
+echo "test nodejs runtime with provision config ..."
+cd nodejs
+cd provision
+export fc_component_function_name=nodejs18-provision-$(uname)-$(uname -m)-$RANDSTR
+s deploy -y
+s info -y
+sleep 2
+s deploy -y -t ./s2.yaml
+s info -y -t ./s2.yaml
+s remove -y -t ./s2.yaml
+cd ..
 
 echo "test nodejs runtime with provision config mode=drain  ..."
-cd nodejs
 export fc_component_function_name=nodejs18-provision-drain-$(uname)-$(uname -m)-$RANDSTR
 s deploy -y -t s_provision_drain.yaml
 s invoke -e '{"hello":"fc nodejs provision config mode=drain"}' -t s_provision_drain.yaml

--- a/__tests__/e2e/nodejs/provision/code/index.js
+++ b/__tests__/e2e/nodejs/provision/code/index.js
@@ -1,0 +1,14 @@
+'use strict';
+/*
+To enable the initializer feature (https://help.aliyun.com/document_detail/2512970.html)
+please implement the initializer function as below：
+exports.initializer = (context, callback) => {
+  console.log('initializing');
+  callback(null, '');
+};
+*/
+exports.handler = (event, context, callback) => {
+  // const eventObj = JSON.parse(event.toString());
+  console.log('hello world');
+  callback(null, 'hello world');
+};

--- a/__tests__/e2e/nodejs/provision/s.yaml
+++ b/__tests__/e2e/nodejs/provision/s.yaml
@@ -1,0 +1,34 @@
+edition: 3.0.0
+name: fc3-example
+access: quanxi
+
+vars: 
+  region: ${env('REGION', 'cn-hongkong')}
+
+resources:
+  fcDemo:
+    component: ${env('fc_component_version', path('../../../../'))}
+    props:
+      region: ${vars.region}
+      handler: index.handler
+      role: ''
+      description: ''
+      timeout: 60
+      diskSize: 512
+      internetAccess: true
+      logConfig: auto
+      functionName: fc3-provision-${env('fc_component_function_name', 'provision')}
+      runtime: nodejs16
+      cpu: 0.35
+      memorySize: 512
+      code: ./code
+      provisionConfig:
+        target: 1
+        targetTrackingPolicies:
+          - name: test
+            metricType: ProvisionedConcurrencyUtilization
+            metricTarget: 0.6
+            startTime: '2026-01-20T04:00:00.000Z'
+            endTime: '2026-01-20T07:00:00.000Z'
+            minCapacity: 1
+            maxCapacity: 5

--- a/__tests__/e2e/nodejs/provision/s2.yaml
+++ b/__tests__/e2e/nodejs/provision/s2.yaml
@@ -1,0 +1,26 @@
+edition: 3.0.0
+name: fc3-example
+access: quanxi
+
+vars: 
+  region: ${env('REGION', 'cn-hongkong')}
+
+resources:
+  fcDemo:
+    component: ${env('fc_component_version', path('../../../../'))}
+    props:
+      region: ${vars.region}
+      handler: index.handler
+      role: ''
+      description: ''
+      timeout: 60
+      diskSize: 512
+      internetAccess: true
+      logConfig: auto
+      functionName: fc3-provision-${env('fc_component_function_name', 'provision')}
+      runtime: nodejs16
+      cpu: 0.35
+      memorySize: 512
+      code: ./code
+      provisionConfig:
+        target: 0

--- a/__tests__/ut/commands/deploy/impl/scaling_config_test.ts
+++ b/__tests__/ut/commands/deploy/impl/scaling_config_test.ts
@@ -398,7 +398,11 @@ describe('ScalingConfig', () => {
         'ScalingConfig',
         'test-function',
         'LATEST',
-        { minInstances: 1 },
+        {
+          horizontalScalingPolicies: [],
+          scheduledPolicies: [],
+          minInstances: 1,
+        },
       );
       expect(logger.info).toHaveBeenCalledWith(
         'ScalingConfig of test-function/LATEST is ready. CurrentInstances: 1, TargetInstances: 1',
@@ -446,10 +450,16 @@ describe('ScalingConfig', () => {
         'ScalingConfig',
         'test-function',
         'LATEST',
-        { minInstances: 1 },
+        {
+          horizontalScalingPolicies: [],
+          scheduledPolicies: [],
+          minInstances: 1,
+        },
       );
       expect(waitForScalingReadySpy).toHaveBeenCalledWith('LATEST', {
+        horizontalScalingPolicies: [],
         minInstances: 1,
+        scheduledPolicies: [],
       });
     });
 
@@ -489,7 +499,11 @@ describe('ScalingConfig', () => {
         'ScalingConfig',
         'test-function',
         'LATEST',
-        { minInstances: 1 },
+        {
+          horizontalScalingPolicies: [],
+          scheduledPolicies: [],
+          minInstances: 1,
+        },
       );
       expect(waitForScalingReadySpy).not.toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith(

--- a/src/subCommands/deploy/impl/scaling_config.ts
+++ b/src/subCommands/deploy/impl/scaling_config.ts
@@ -45,6 +45,12 @@ export default class ScalingConfig extends Base {
 
     if (!_.isEmpty(localConfig)) {
       if (this.needDeploy) {
+        const defaultArrayProps = ['horizontalScalingPolicies', 'scheduledPolicies'];
+        for (const prop of defaultArrayProps) {
+          if (!Array.isArray(localConfig[prop])) {
+            localConfig[prop] = [];
+          }
+        }
         await provisionConfigErrorRetry(
           this.fcSdk,
           'ScalingConfig',

--- a/src/subCommands/deploy/utils/index.ts
+++ b/src/subCommands/deploy/utils/index.ts
@@ -3,10 +3,10 @@ import { isProvisionConfigError, sleep } from '../../../utils';
 
 export async function provisionConfigErrorRetry(
   fcSdk: any,
-  command,
-  functionName,
-  qualifier,
-  localConfig,
+  command: string,
+  functionName: string,
+  qualifier: string,
+  localConfig: any,
 ) {
   logger.info(`provisionConfigErrorRetry Execute： ${command}`);
   try {

--- a/src/subCommands/model/utils/index.ts
+++ b/src/subCommands/model/utils/index.ts
@@ -55,7 +55,7 @@ export const initClient = async (inputs: IInputs, region: string, solution: stri
     }`,
   });
 
-  logger.info(`new models service init, DEVS_ENDPOINT endpoint: ${config.endpoint}`);
+  logger.info(`DEVS_ENDPOINT endpoint: ${config.endpoint}`);
 
   return new DevClient(config);
 };


### PR DESCRIPTION
- Add default empty array initialization for targetTrackingPolicies and scheduledActions in provisionConfig
- Add default empty array initialization for horizontalScalingPolicies and scheduledPolicies in scalingConfig
- Fix variable naming conflict with 'target' in provisionConfig
- Update test cases to include new required properties
- Add e2e test for nodejs provision config
- Remove redundant log message in model utils