### PR TITLE
fix: use quoted full-text search instead of field-specific SLS query …

### DIFF
--- a/__tests__/ut/commands/logs_test.ts
+++ b/__tests__/ut/commands/logs_test.ts
@@ -565,7 +565,7 @@ describe('Logs', () => {
       );
 
       expect(result).toBe(
-        '__topic__:"FCLogs:test-function" and baseQuery and searchTerm and qualifier: "LATEST" and instanceID: "inst-456" and requestId: "req-123"',
+        '__topic__:"FCLogs:test-function" and baseQuery and searchTerm and "LATEST" and "inst-456" and "req-123"',
       );
     });
 
@@ -592,7 +592,7 @@ describe('Logs', () => {
       );
 
       expect(result).toBe(
-        '(__topic__:"FCLogs:test-function" or __topic__:"FCInstanceEvents:/test-function") and instanceID: "inst-456"',
+        '(__topic__:"FCLogs:test-function" or __topic__:"FCInstanceEvents:/test-function") and "inst-456"',
       );
     });
 
@@ -609,7 +609,7 @@ describe('Logs', () => {
       expect(result).toBe('__topic__:"FCLogs:test-function"');
     });
 
-    it('should use field-specific syntax for qualifier', () => {
+    it('should use quoted full-text search for qualifier', () => {
       const result = (logs as any).getSlsQuery(
         null,
         null,
@@ -619,7 +619,7 @@ describe('Logs', () => {
         '__topic__:"FCLogs:test-function"',
       );
 
-      expect(result).toBe('__topic__:"FCLogs:test-function" and qualifier: "LATEST"');
+      expect(result).toBe('__topic__:"FCLogs:test-function" and "LATEST"');
     });
   });
 

--- a/publish.yaml
+++ b/publish.yaml
@@ -3,7 +3,7 @@ Type: Component
 Name: fc3
 Provider:
   - 阿里云
-Version: 0.1.19
+Version: 0.1.20
 Description: 阿里云函数计算全生命周期管理
 HomePage: https://github.com/devsapp/fc3
 Organization: 阿里云函数计算（FC）

--- a/src/subCommands/logs/index.ts
+++ b/src/subCommands/logs/index.ts
@@ -297,7 +297,7 @@ export default class Logs {
       // }
 
       if (match) {
-        l = replaceAll(l, match, `\x1B[43m${match}\x1B[0m`);
+        l = replaceAll(l, match, `\x1B[7m${match}\x1B[0m`);
       }
 
       console.log(l);
@@ -477,17 +477,17 @@ export default class Logs {
     }
 
     if (!_.isNil(qualifier)) {
-      q = hasValue ? `${q} and qualifier: "${qualifier}"` : `qualifier: "${qualifier}"`;
+      q = hasValue ? `${q} and "${qualifier}"` : `"${qualifier}"`;
       hasValue = true;
     }
 
     if (!_.isNil(instanceId)) {
-      q = hasValue ? `${q} and instanceID: "${instanceId}"` : `instanceID: "${instanceId}"`;
+      q = hasValue ? `${q} and "${instanceId}"` : `"${instanceId}"`;
       hasValue = true;
     }
 
     if (!_.isNil(requestId)) {
-      q = hasValue ? `${q} and requestId: "${requestId}"` : `requestId: "${requestId}"`;
+      q = hasValue ? `${q} and "${requestId}"` : `"${requestId}"`;
     }
 
     return q;


### PR DESCRIPTION
…syntax

Field-specific SLS syntax (e.g. requestId: "value") requires key-value index configuration which FC3's default logstore doesn't have, causing "key (requestId) is not config as key value config" errors. Switch to quoted full-text search ("value") which works with the default full-text index configuration.

Change-Id: If44111b49fc8bcb9ad6663497f18fa40248106ae
Co-developed-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated SLS query syntax formatting for log queries.
  * Version incremented to 0.1.20.

* **Style**
  * Changed match highlighting display from yellow background to reverse-video styling for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->