### PR TITLE
feat: resolve ${env('...')} variables in cloud build yaml before parsing

### DIFF
--- a/__tests__/ut/commands/build_test.ts
+++ b/__tests__/ut/commands/build_test.ts
@@ -1,4 +1,4 @@
-import BuilderFactory, { BuildType } from '../../../src/subCommands/build';
+import BuilderFactory, { BuildType, resolveEnvVariables } from '../../../src/subCommands/build';
 import { ImageBuiltKitBuilder } from '../../../src/subCommands/build/impl/imageBuiltKitBuilder';
 import { ImageDockerBuilder } from '../../../src/subCommands/build/impl/imageDockerBuilder';
 import { ImageKanikoBuilder } from '../../../src/subCommands/build/impl/imageKanikoBuilder';
@@ -300,6 +300,45 @@ describe('BuilderFactory', () => {
 
       expect(builder1).toBe(mockBuilder1);
       expect(builder2).toBe(mockBuilder2);
+    });
+  });
+
+  describe('resolveEnvVariables', () => {
+    it('should replace env variables with single quotes', () => {
+      process.env.MY_VAR = 'hello';
+      const result = resolveEnvVariables("value: ${env('MY_VAR')}");
+      expect(result).toBe('value: hello');
+      delete process.env.MY_VAR;
+    });
+
+    it('should replace env variables with double quotes', () => {
+      process.env.MY_VAR = 'world';
+      const result = resolveEnvVariables('value: ${env("MY_VAR")}');
+      expect(result).toBe('value: world');
+      delete process.env.MY_VAR;
+    });
+
+    it('should replace multiple env variables', () => {
+      process.env.USERNAME = 'admin';
+      process.env.PASSWORD = 'secret';
+      const result = resolveEnvVariables(
+        "username: ${env('USERNAME')}\npassword: ${env('PASSWORD')}",
+      );
+      expect(result).toBe('username: admin\npassword: secret');
+      delete process.env.USERNAME;
+      delete process.env.PASSWORD;
+    });
+
+    it('should throw error when env variable is not found', () => {
+      delete process.env.NOT_EXIST;
+      expect(() => resolveEnvVariables("value: ${env('NOT_EXIST')}")).toThrow(
+        'Environment variable not found: NOT_EXIST',
+      );
+    });
+
+    it('should not modify content without env variables', () => {
+      const content = 'region: cn-hangzhou\nruntime: nodejs18';
+      expect(resolveEnvVariables(content)).toBe(content);
     });
   });
 });

--- a/src/subCommands/build/index.ts
+++ b/src/subCommands/build/index.ts
@@ -22,6 +22,17 @@ export enum BuildType {
   Default = 'DEFAULT',
 }
 
+export function resolveEnvVariables(content: string): string {
+  return content.replace(/\$\{env\(['"](.+?)['"]\)\}/g, (match, envName: string) => {
+    const value = process.env[envName];
+    if (value === undefined) {
+      logger.error(`Environment variable not found: ${envName}`);
+      throw new Error(`Environment variable not found: ${envName}`);
+    }
+    return value;
+  });
+}
+
 export default class BuilderFactory {
   private inputs: IInputs;
   private debugInstance: boolean;
@@ -73,7 +84,8 @@ export default class BuilderFactory {
 
     try {
       const buildYamlContent = fs.readFileSync(buildYamlPath, 'utf8');
-      const buildConfig = yaml.load(buildYamlContent) as any;
+      const resolvedContent = resolveEnvVariables(buildYamlContent);
+      const buildConfig = yaml.load(resolvedContent) as any;
 
       // 从build.yaml中提取配置，支持多种格式
       let config = buildConfig;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build configuration files now support environment variable substitution using `${env('VAR')}` syntax. Variables are automatically resolved during the build process, with error handling for missing variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsapp/fc3/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->